### PR TITLE
Fix bug in sorting terms with hierarchical category

### DIFF
--- a/gecka-terms-ordering.php
+++ b/gecka-terms-ordering.php
@@ -359,7 +359,7 @@ class Gecka_Terms_Ordering {
 	
 		foreach ( $children as $term ) {
 			$index ++;
-			$index = $this->set_term_order ( $term->term_id, $index, true );		
+			$index = $this->set_term_order ( $term->term_id, $taxonomy, $index, true );
 		}
 		
 		return $index;


### PR DESCRIPTION
There is a bug in sorting terms with hierarchical category or taxonomy.
When drag a parent term, the order is not saved correctly.

Fix it adding an argument to place_term() function.
