### PR TITLE
Improve compatibility with DB changes in  WordPress 4.2 and 4.4.

### DIFF
--- a/gecka-terms-ordering.php
+++ b/gecka-terms-ordering.php
@@ -113,21 +113,29 @@ class Gecka_Terms_Ordering {
 	    
 	    global $wpdb;
 	    
-	    $collate = '';
-	    if($wpdb->supports_collation()) {
-			if(!empty($wpdb->charset)) $collate = "DEFAULT CHARACTER SET $wpdb->charset";
-			if(!empty($wpdb->collate)) $collate .= " COLLATE $wpdb->collate";
-	    }
-	    
-	    $sql = "CREATE TABLE IF NOT EXISTS ". $wpdb->prefix . "termmeta" ." (
-	            `meta_id` bigint(20) unsigned NOT NULL auto_increment,
-	            `term_id` bigint(20) unsigned NOT NULL default '0',
-	            `meta_key` varchar(255) default NULL,
-	            `meta_value` longtext,
-	            PRIMARY KEY (meta_id),
-	            KEY term_id (term_id),
-	            KEY meta_key (meta_key) ) $collate;";
-	    $wpdb->query($sql);
+			/**
+			 * Create the termmeta database table, for WordPress < version 4.4.
+			 *
+			 * The max index length is required since 4.2, because of the move to utf8mb4 collation.
+			 *
+			 * @see wp_get_db_schema()
+			 */
+			$charset_collate = $wpdb->get_charset_collate();
+			$table_name = $wpdb->prefix . "termmeta";
+			$max_index_length = 191;
+
+			$sql = "CREATE TABLE IF NOT EXISTS $table_name (
+				meta_id bigint(20) unsigned NOT NULL auto_increment,
+				term_id bigint(20) unsigned NOT NULL default '0',
+				meta_key varchar(255) default NULL,
+				meta_value longtext,
+				PRIMARY KEY  (meta_id),
+				KEY term_id (term_id),
+				KEY meta_key (meta_key($max_index_length))
+			) $charset_collate;";
+
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+			dbDelta( $sql );
 	    
 	}	
     
@@ -154,7 +162,9 @@ class Gecka_Terms_Ordering {
     public function metadata_wpdbfix () {
     	
     	global $wpdb;
-	  	$wpdb->termmeta = "{$wpdb->prefix}termmeta";
+			if ( ! isset( $wpdb->termmeta ) ) {
+				$wpdb->termmeta = "{$wpdb->prefix}termmeta";
+			}
 	  	
     }
     


### PR DESCRIPTION
This updates the plugin to improve compatibility with recent changes in WP core. Version 4.2 introduced a conversion to utf8mb4 collation for all database tables, and version 4.4 will introduce the new `termmeta` table, which is already in use by this plugin.
