### PR TITLE
Fix SQL syntax error

### DIFF
--- a/gecka-terms-ordering.php
+++ b/gecka-terms-ordering.php
@@ -344,12 +344,13 @@ class Gecka_Terms_Ordering {
 			$args['menu_order'] = 'ASC';
 		}
 
-		$order = "ORDER BY CAST(tm.meta_value AS SIGNED) " . $args['menu_order'];
+		$order = "ORDER BY CAST(tm.meta_value AS SIGNED)";
 
 		if ( $clauses['orderby'] ) {
-			$clauses['orderby'] = str_replace( 'ORDER BY', $order . ',', $clauses['orderby'] );
+			$clauses['orderby'] = str_replace( 'ORDER BY', $order . ' ' . $args['menu_order'] . ',', $clauses['orderby'] );
 		} else {
 			$clauses['orderby'] = $order;
+			$clauses['order'] = $args['menu_order'];
 		}
 
 		return $clauses;


### PR DESCRIPTION
This is a fix for the following error:

>WordPress database error: [You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ASC' at line 1]
SELECT t.*, tt.*, tm.meta_key, tm.meta_value FROM wp_terms AS t INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id LEFT JOIN wp_termmeta AS tm ON (t.term_id = tm.term_id AND tm.meta_key = 'order') WHERE tt.taxonomy IN ('project_categories') AND t.slug IN ('branding') ORDER BY CAST(tm.meta_value AS SIGNED) ASC ASC

With the previous code, both `$clauses['orderby']` and `$clauses['order']` contained the string “ASC”, which resulted in the “ASC ASC” at the end of the query.